### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "lodash": "^4.13.1",
     "loginless": "^1.0.1",
     "mangler": "^1.0.1",
-    "node-uuid": "^1.4.7",
     "rest.js": "~0.0.8",
-    "socket.io-client": "^1.4.6"
+    "socket.io-client": "^1.4.6",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "del": "^2.2.0",

--- a/src/account.js
+++ b/src/account.js
@@ -1,6 +1,6 @@
 module.exports = function (serverResponse, loginless, socket, insightutil) {
   var bluebird    = require('bluebird')
-  var nodeUUID    = require('node-uuid')
+  var nodeUUID    = require('uuid')
   var assert      = require('affirm.js')
   var _           = require('lodash')
   var mangler     = require('mangler')


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.